### PR TITLE
initial SHAKE-128/SHAKE-256 ACVP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ The other commands are as follows. (Note that you only need to implement the com
 | SHA2-512             | Value to hash             | Digest  |
 | SHA2-512/224         | Value to hash             | Digest  |
 | SHA2-512/256         | Value to hash             | Digest  |
+| SHA3-224             | Value to hash             | Digest  |
+| SHA3-256             | Value to hash             | Digest  |
+| SHA3-384             | Value to hash             | Digest  |
+| SHA3-512             | Value to hash             | Digest  |
+| SHAKE                | Value to hash             | Digest  |
+| SHAKE/VOT            | Value to hash, output length bits | Digest |
+| SHAKE/MCT            | Initial seed¹, min output bits, max output bits, output length bits | Digest, output length bits |
 | SHA-1/MCT            | Initial seed¹             | Digest  |
 | SHA2-224/MCT         | Initial seed¹             | Digest  |
 | SHA2-256/MCT         | Initial seed¹             | Digest  |
@@ -115,6 +122,10 @@ The other commands are as follows. (Note that you only need to implement the com
 | SHA2-512/MCT         | Initial seed¹             | Digest  |
 | SHA2-512/224/MCT     | Initial seed¹             | Digest  |
 | SHA2-512/256/MCT     | Initial seed¹             | Digest  |
+| SHA3-224/MCT         | Initial seed¹             | Digest  |
+| SHA3-256/MCT         | Initial seed¹             | Digest  |
+| SHA3-384/MCT         | Initial seed¹             | Digest  |
+| SHA3-512/MCT         | Initial seed¹             | Digest  |
 | TLSKDF/1.2/&lt;HASH&gt; | Number output bytes, secret, label, seed1, seed2 | Output |
 | PBKDF                | HMAC name, key length (bits), salt, password, iteration count | Derived key |
 

--- a/subprocess/shake.go
+++ b/subprocess/shake.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2024, Google Inc.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+package subprocess
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+)
+
+// The following structures reflect the JSON of ACVP shake tests. See
+// https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html#name-test-vectors
+
+type shakeTestVectorSet struct {
+	Groups []shakeTestGroup `json:"testGroups"`
+}
+
+type shakeTestGroup struct {
+	ID            uint64 `json:"tgId"`
+	Type          string `json:"testType"`
+	MaxOutLenBits uint32 `json:"maxOutLen"`
+	MinOutLenBits uint32 `json:"minOutLen"`
+	Tests         []struct {
+		ID           uint64 `json:"tcId"`
+		BitLength    uint64 `json:"len"`
+		BitOutLength uint32 `json:"outLen"`
+		MsgHex       string `json:"msg"`
+	} `json:"tests"`
+}
+
+type shakeTestGroupResponse struct {
+	ID    uint64              `json:"tgId"`
+	Tests []shakeTestResponse `json:"tests"`
+}
+
+type shakeTestResponse struct {
+	ID         uint64           `json:"tcId"`
+	DigestHex  string           `json:"md,omitempty"`
+	MCTResults []shakeMCTResult `json:"resultsArray,omitempty"`
+}
+
+type shakeMCTResult struct {
+	DigestHex string `json:"md"`
+	OutputLen uint32 `json:"outLen,omitempty"`
+}
+
+// shake implements an ACVP algorithm by making requests to the
+// subprocess to hash strings.
+type shake struct {
+	// algo is the ACVP name for this algorithm and also the command name
+	// given to the subprocess to hash with this hash function.
+	algo string
+	// size is the number of bytes of digest that the hash produces for AFT tests.
+	size int
+}
+
+func (h *shake) Process(vectorSet []byte, m Transactable) (any, error) {
+	var parsed shakeTestVectorSet
+	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
+		return nil, err
+	}
+
+	var ret []shakeTestGroupResponse
+	// See
+	// https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html#name-test-types
+	// for details about the tests.
+	for _, group := range parsed.Groups {
+		group := group
+		response := shakeTestGroupResponse{
+			ID: group.ID,
+		}
+
+		for _, test := range group.Tests {
+			test := test
+
+			if uint64(len(test.MsgHex))*4 != test.BitLength {
+				return nil, fmt.Errorf("test case %d/%d contains hex message of length %d but specifies a bit length of %d", group.ID, test.ID, len(test.MsgHex), test.BitLength)
+			}
+			msg, err := hex.DecodeString(test.MsgHex)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode hex in test case %d/%d: %s", group.ID, test.ID, err)
+			}
+
+			switch group.Type {
+			case "AFT":
+				// "AFTs all produce a single digest size, matching the security strength of the extendable output function."
+				if test.BitOutLength != uint32(h.size*8) {
+					return nil, fmt.Errorf("AFT test case %d/%d has bit length %d but expected %d", group.ID, test.ID, test.BitLength, h.size*8)
+				}
+
+				m.TransactAsync(h.algo, 1, [][]byte{msg, uint32le(test.BitOutLength)}, func(result [][]byte) error {
+					response.Tests = append(response.Tests, shakeTestResponse{
+						ID:        test.ID,
+						DigestHex: hex.EncodeToString(result[0]),
+					})
+					return nil
+				})
+			case "VOT":
+				// "The VOTs SHALL produce varying digest sizes based on the capabilities of the IUT"
+				m.TransactAsync(h.algo+"/VOT", 1, [][]byte{msg, uint32le(test.BitOutLength)}, func(result [][]byte) error {
+					response.Tests = append(response.Tests, shakeTestResponse{
+						ID:        test.ID,
+						DigestHex: hex.EncodeToString(result[0]),
+					})
+					return nil
+				})
+			case "MCT":
+				// https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html#name-shake-monte-carlo-test
+				testResponse := shakeTestResponse{ID: test.ID}
+
+				digest := msg
+				minOutLenBits := uint32le(group.MinOutLenBits)
+				maxOutLenBits := uint32le(group.MaxOutLenBits)
+				outputLenBits := uint32le(group.MaxOutLenBits)
+
+				for i := 0; i < 100; i++ {
+					args := [][]byte{digest, minOutLenBits, maxOutLenBits, outputLenBits}
+					result, err := m.Transact(h.algo+"/MCT", 2, args...)
+					if err != nil {
+						panic(h.algo + " mct operation failed: " + err.Error())
+					}
+
+					digest = result[0]
+					outputLenBits = uint32le(binary.LittleEndian.Uint32(result[1]))
+					mctResult := shakeMCTResult{DigestHex: hex.EncodeToString(digest), OutputLen: uint32(len(digest) * 8)}
+					testResponse.MCTResults = append(testResponse.MCTResults, mctResult)
+				}
+
+				response.Tests = append(response.Tests, testResponse)
+			default:
+				return nil, fmt.Errorf("test group %d has unknown type %q", group.ID, group.Type)
+			}
+		}
+
+		m.Barrier(func() {
+			ret = append(ret, response)
+		})
+	}
+
+	if err := m.Flush(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}

--- a/subprocess/subprocess.go
+++ b/subprocess/subprocess.go
@@ -108,6 +108,8 @@ func NewWithIO(cmd *exec.Cmd, in io.WriteCloser, out io.ReadCloser) *Subprocess 
 		"SHA3-256":          &hashPrimitive{"SHA3-256", 32},
 		"SHA3-384":          &hashPrimitive{"SHA3-384", 48},
 		"SHA3-512":          &hashPrimitive{"SHA3-512", 64},
+		"SHAKE-128":         &shake{"SHAKE-128", 16},
+		"SHAKE-256":         &shake{"SHAKE-256", 32},
 		"ACVP-AES-ECB":      &blockCipher{"AES", 16, 2, true, false, iterateAES},
 		"ACVP-AES-CBC":      &blockCipher{"AES-CBC", 16, 2, true, true, iterateAESCBC},
 		"ACVP-AES-CBC-CS3":  &blockCipher{"AES-CBC-CS3", 16, 1, false, true, iterateAESCBC},


### PR DESCRIPTION
Adds support for SHAKE-128 and SHAKE-256 ACVP. The AFT test type is very similar to the existing `hashPrimitive`'s AFT test, but since VOT and MCT are quite different it felt prudent to make a new primitive for SHAKE.

The command table is also updated to describe the pre-existing SHA3 commands that were missing prior to this branch.

For more information see:
https://pages.nist.gov/ACVP/draft-celi-acvp-sha3.html