### PR TITLE
subprocess: add support for DetECDSA

### DIFF
--- a/subprocess/ecdsa.go
+++ b/subprocess/ecdsa.go
@@ -25,8 +25,9 @@ import (
 // https://pages.nist.gov/ACVP/draft-fussell-acvp-ecdsa.html#name-test-vectors
 
 type ecdsaTestVectorSet struct {
-	Groups []ecdsaTestGroup `json:"testGroups"`
-	Mode   string           `json:"mode"`
+	Groups    []ecdsaTestGroup `json:"testGroups"`
+	Mode      string           `json:"mode"`
+	Algorithm string           `json:"algorithm"`
 }
 
 type ecdsaTestGroup struct {
@@ -76,6 +77,10 @@ func (e *ecdsa) Process(vectorSet []byte, m Transactable) (any, error) {
 	var parsed ecdsaTestVectorSet
 	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
 		return nil, err
+	}
+
+	if parsed.Algorithm == "DetECDSA" && parsed.Mode != "sigGen" {
+		return nil, fmt.Errorf("DetECDSA only specifies sigGen mode")
 	}
 
 	var ret []ecdsaTestGroupResponse
@@ -139,6 +144,10 @@ func (e *ecdsa) Process(vectorSet []byte, m Transactable) (any, error) {
 				})
 
 			case "sigGen":
+				if group.ComponentTest && parsed.Algorithm == "DetECDSA" {
+					return nil, fmt.Errorf("DetECDSA does not support component tests")
+				}
+
 				p := e.primitives[group.HashAlgo]
 				h, ok := p.(*hashPrimitive)
 				if !ok {

--- a/subprocess/subprocess.go
+++ b/subprocess/subprocess.go
@@ -146,6 +146,7 @@ func NewWithIO(cmd *exec.Cmd, in io.WriteCloser, out io.ReadCloser) *Subprocess 
 		"PBKDF":             &pbkdf{},
 	}
 	m.primitives["ECDSA"] = &ecdsa{"ECDSA", map[string]bool{"P-224": true, "P-256": true, "P-384": true, "P-521": true}, m.primitives}
+	m.primitives["DetECDSA"] = &ecdsa{"ECDSA", map[string]bool{"P-224": true, "P-256": true, "P-384": true, "P-521": true}, m.primitives}
 	m.primitives["EDDSA"] = &eddsa{"EDDSA", map[string]bool{"ED-25519": true}}
 
 	go m.readerRoutine()


### PR DESCRIPTION
Very little needs to change in order to support the deterministic ACVP algorithm spec from [the NIST spec](https://pages.nist.gov/ACVP/draft-fussell-acvp-ecdsa.html).