### PR TITLE
subprocess: add support for SSH KDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ The other commands are as follows. (Note that you only need to implement the com
 | SHA3-512/MCT         | Initial seed¹             | Digest  |
 | TLSKDF/1.2/&lt;HASH&gt; | Number output bytes, secret, label, seed1, seed2 | Output |
 | PBKDF                | HMAC name, key length (bits), salt, password, iteration count | Derived key |
+| SSHKDF/&lt;HASH&gt;/client | K, H, SessionID, cipher algorithm | client IV key, client encryption key, client integrity key |
+| SSHKDF/&lt;HASH&gt;/server | K, H, SessionID, cipher algorithm | server IV key, server encryption key, server integrity key |
 
 ¹ The iterated tests would result in excessive numbers of round trips if the module wrapper handled only basic operations. Thus some ACVP logic is pushed down for these tests so that the inner loop can be handled locally. Either read the NIST documentation ([block-ciphers](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html#name-monte-carlo-tests-for-block) [hashes](https://pages.nist.gov/ACVP/draft-celi-acvp-sha.html#name-monte-carlo-tests-for-sha-1)) to understand the iteration count and return values or, probably more fruitfully, see how these functions are handled in the `modulewrapper` directory.
 

--- a/subprocess/ssh.go
+++ b/subprocess/ssh.go
@@ -1,0 +1,127 @@
+package subprocess
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+)
+
+// The following structures reflect the JSON of KDF SSH tests. See
+// https://pages.nist.gov/ACVP/draft-celi-acvp-kdf-ssh.html#name-test-vectors
+
+type sshTestVectorSet struct {
+	Algorithm string         `json:"algorithm"`
+	Mode      string         `json:"mode"`
+	Groups    []sshTestGroup `json:"testGroups"`
+}
+
+type sshTestGroup struct {
+	ID       uint64 `json:"tgId"`
+	TestType string `json:"testType"`
+	HashAlg  string `json:"hashAlg"`
+	Cipher   string `json:"cipher"`
+	Tests    []struct {
+		ID           uint64 `json:"tcId"`
+		KHex         string `json:"k"`
+		HHex         string `json:"h"`
+		SessionIDHex string `json:"sessionID"`
+	} `json:"tests"`
+}
+
+type sshTestGroupResponse struct {
+	ID    uint64            `json:"tgId"`
+	Tests []sshTestResponse `json:"tests"`
+}
+
+type sshTestResponse struct {
+	ID                     uint64 `json:"tcId"`
+	InitialIvClientHex     string `json:"initialIvClient"`
+	InitialIvServerHex     string `json:"initialIvServer"`
+	EncryptionKeyClientHex string `json:"encryptionKeyClient"`
+	EncryptionKeyServerHex string `json:"encryptionKeyServer"`
+	IntegrityKeyClientHex  string `json:"integrityKeyClient"`
+	IntegrityKeyServerHex  string `json:"integrityKeyServer"`
+}
+
+type ssh struct {
+}
+
+func (s *ssh) Process(vectorSet []byte, m Transactable) (any, error) {
+	var parsed sshTestVectorSet
+	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
+		return nil, err
+	}
+
+	if parsed.Algorithm != "kdf-components" {
+		return nil, fmt.Errorf("unexpected algorithm: %q", parsed.Algorithm)
+	}
+	if parsed.Mode != "ssh" {
+		return nil, fmt.Errorf("unexpected mode: %q", parsed.Mode)
+	}
+
+	var ret []sshTestGroupResponse
+	for _, group := range parsed.Groups {
+		group := group
+
+		// Only the AFT test type is specified for SSH:
+		// https://pages.nist.gov/ACVP/draft-celi-acvp-kdf-ssh.html#name-test-types
+		if group.TestType != "AFT" {
+			return nil, fmt.Errorf("test group %d had unexpected test type: %q", group.ID, group.TestType)
+		}
+
+		response := sshTestGroupResponse{
+			ID: group.ID,
+		}
+
+		for _, test := range group.Tests {
+			test := test
+
+			resp := sshTestResponse{
+				ID: test.ID,
+			}
+
+			k, err := hex.DecodeString(test.KHex)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode K hex in test case %d/%d: %s", group.ID, test.ID, err)
+			}
+			h, err := hex.DecodeString(test.HHex)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode H hex in test case %d/%d: %s", group.ID, test.ID, err)
+			}
+			sessionID, err := hex.DecodeString(test.SessionIDHex)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode session ID hex in test case %d/%d: %s", group.ID, test.ID, err)
+			}
+
+			cmd := fmt.Sprintf("SSHKDF/%s/client", group.HashAlg)
+			m.TransactAsync(cmd, 3, [][]byte{k, h, sessionID, []byte(group.Cipher)}, func(result [][]byte) error {
+				resp.InitialIvClientHex = hex.EncodeToString(result[0])
+				resp.EncryptionKeyClientHex = hex.EncodeToString(result[1])
+				resp.IntegrityKeyClientHex = hex.EncodeToString(result[2])
+				return nil
+			})
+
+			cmd = fmt.Sprintf("SSHKDF/%s/server", group.HashAlg)
+			m.TransactAsync(cmd, 3, [][]byte{k, h, sessionID, []byte(group.Cipher)}, func(result [][]byte) error {
+				resp.InitialIvServerHex = hex.EncodeToString(result[0])
+				resp.EncryptionKeyServerHex = hex.EncodeToString(result[1])
+				resp.IntegrityKeyServerHex = hex.EncodeToString(result[2])
+				return nil
+			})
+
+			m.Barrier(func() {
+				response.Tests = append(response.Tests, resp)
+			})
+		}
+
+		m.Barrier(func() {
+			ret = append(ret, response)
+		})
+	}
+
+	if err := m.Flush(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}

--- a/subprocess/subprocess.go
+++ b/subprocess/subprocess.go
@@ -144,6 +144,7 @@ func NewWithIO(cmd *exec.Cmd, in io.WriteCloser, out io.ReadCloser) *Subprocess 
 		"KAS-ECC-SSC":       &kas{},
 		"KAS-FFC-SSC":       &kasDH{},
 		"PBKDF":             &pbkdf{},
+		"kdf-components":    &ssh{},
 	}
 	m.primitives["ECDSA"] = &ecdsa{"ECDSA", map[string]bool{"P-224": true, "P-256": true, "P-384": true, "P-521": true}, m.primitives}
 	m.primitives["DetECDSA"] = &ecdsa{"DetECDSA", map[string]bool{"P-224": true, "P-256": true, "P-384": true, "P-521": true}, m.primitives}


### PR DESCRIPTION
This commit updates the acvptool subprocess handling to support the SSH KDF ACVP tests specified in:

  https://pages.nist.gov/ACVP/draft-celi-acvp-kdf-ssh.html

These vectors use the algorithm "kdf-components" and the mode "ssh". Module wrappers that advertise capabilities that include this algo/mode need to implement two new commands (described in ACVP.md):

1. "SSHKDF/$HASH/client" for deriving client direction keys.
2. "SSHKDF/$HASH/server" for deriving server direction keys.

Both commands take K, H, SessionID and a cipher name as input and return the IV key, the encryption key, and the integrity key for their respective direction.