### PR TITLE
docs: adjust KDF-counter command docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The other commands are as follows. (Note that you only need to implement the com
 | hmacDRBG/&lt;HASH&gt;| Output length, entropy, personalisation, ad1, ad2, nonce | Output |
 | hmacDRBG-reseed/&lt;HASH&gt;| Output length, entropy, personalisation, reseedAD, reseedEntropy, ad1, ad2, nonce | Output |
 | hmacDRBG-pr/&lt;HASH&gt;| Output length, entropy, personalisation, ad1, entropy1, ad2, entropy2, nonce | Output |
-| KDF-counter          | Number output bytes, PRF name, counter location string, key, number of counter bits | Counter, output |
+| KDF-counter          | Number output bytes, PRF name, counter location string, key (or empty), number of counter bits | key, counter, derived key |
 | RSA/keyGen           | Modulus bit-size | e, p, q, n, d |
 | RSA/sigGen/&lt;HASH&gt;/pkcs1v1.5 | Modulus bit-size | n, e, signature |
 | RSA/sigGen/&lt;HASH&gt;/pss       | Modulus bit-size | n, e, signature |


### PR DESCRIPTION
This commit adjusts the README.md documentation for the KDF-counter command to match the implementation.

Prior to this the kdf struct in subprocess that dispatches KDF-counter command invocations had a few divergences from the docs:

* If the test case has the "Deferred" property set to true, then the key argument provided to the wrapper is empty.
* The wrapper is expected to output three values: the input key (since for deferred tests it was generated module-side), the fixed counter data, and the derived key.

For deferred tests the returned key is written to the response `KeyIn`. For non-deferred tests the returned key is verified to match the one that was sent to the submodule as a command arg.