### PR TITLE
implement support for KTS-IFC

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ The other commands are as follows. (Note that you only need to implement the com
 | ML-KEM-XX/encap      | Public key, entropy | Ciphertext, shared secret |
 | ML-KEM-XX/decap      | Private key, ciphertext | Shared secret |
 | OneStepNoCounter/&lt;HASH&gt; | key, info, salt, output length bytes | derived key |
+| KTS-IFC/&lt;HASH&gt;/initiator | output length bytes, serverN bytes, serverE bytes | generated ciphertext (iutC), derived keying material (dkm) |
+| KTS-IFC/&lt;HASH&gt;/responder | iutN bytes, iutE bytes, iutP bytes, iutQ bytes, iutD bytes, ciphertext (serverC) bytes | derived keying material (dkm) |
 
 ¹ The iterated tests would result in excessive numbers of round trips if the module wrapper handled only basic operations. Thus some ACVP logic is pushed down for these tests so that the inner loop can be handled locally. Either read the NIST documentation ([block-ciphers](https://pages.nist.gov/ACVP/draft-celi-acvp-symmetric.html#name-monte-carlo-tests-for-block) [hashes](https://pages.nist.gov/ACVP/draft-celi-acvp-sha.html#name-monte-carlo-tests-for-sha-1)) to understand the iteration count and return values or, probably more fruitfully, see how these functions are handled in the `modulewrapper` directory.
 

--- a/subprocess/kts.go
+++ b/subprocess/kts.go
@@ -1,0 +1,202 @@
+package subprocess
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+)
+
+type ktsVectorSet struct {
+	Groups   []ktsTestGroup `json:"testGroups"`
+	Revision string         `json:"revision"`
+}
+
+type ktsTestGroup struct {
+	ID         uint64    `json:"tgId"`
+	Type       string    `json:"testType"`
+	Scheme     string    `json:"scheme"`
+	Role       string    `json:"kasRole"`
+	Modulo     uint64    `json:"modulo"`
+	KeyGen     string    `json:"keyGenerationMethod"`
+	KTSConf    ktsConfig `json:"ktsConfiguration"`
+	OutputBits uint64    `json:"l"`
+	Tests      []ktsTest `json:"tests"`
+}
+
+type ktsConfig struct {
+	HashAlg               string `json:"hashAlg"`
+	AssociatedDataPattern string `json:"associatedDataPattern"`
+	Encoding              string `json:"encoding"`
+}
+
+type ktsTest struct {
+	ID uint64 `json:"tcId"`
+
+	ServerN string `json:"serverN,omitempty"`
+	ServerE string `json:"serverE,omitempty"`
+	ServerC string `json:"serverC,omitempty"`
+
+	IutN string `json:"iutN,omitempty"`
+	IutE string `json:"iutE,omitempty"`
+	IutP string `json:"iutP,omitempty"`
+	IutQ string `json:"iutQ,omitempty"`
+	IutD string `json:"iutD,omitempty"`
+}
+
+type ktsTestGroupResponse struct {
+	ID    uint64            `json:"tgId"`
+	Tests []ktsTestResponse `json:"tests"`
+}
+
+type ktsTestResponse struct {
+	ID   uint64 `json:"tcId"`
+	IutC string `json:"iutC,omitempty"` // initiator role only
+	Dkm  string `json:"dkm,omitempty"`
+}
+
+type kts struct {
+	hashAlgs map[string]bool // the supported hash algorithm primitives
+}
+
+func (k *kts) Process(vectorSet []byte, m Transactable) (any, error) {
+	var parsed ktsVectorSet
+	if err := json.Unmarshal(vectorSet, &parsed); err != nil {
+		return nil, err
+	}
+
+	if parsed.Revision != "Sp800-56Br2" {
+		return nil, fmt.Errorf("unsupported revision %q", parsed.Revision)
+	}
+
+	var ret []ktsTestGroupResponse
+	for _, group := range parsed.Groups {
+		group := group
+		response := ktsTestGroupResponse{
+			ID: group.ID,
+		}
+
+		if group.Type != "AFT" {
+			return nil, fmt.Errorf("unsupported test type %q in test group %d", group.Type, group.ID)
+		}
+
+		if group.Scheme != "KTS-OAEP-basic" {
+			return nil, fmt.Errorf("unsupported scheme %q in test group %d", group.Scheme, group.ID)
+		}
+
+		if group.KeyGen != "rsakpg1-basic" {
+			return nil, fmt.Errorf("unsupported key generation method %q in test group %d - only fixed public exponent (rsakpg1-basic) is supported", group.KeyGen, group.ID)
+		}
+
+		if group.OutputBits%8 != 0 {
+			return nil, fmt.Errorf("%d bit L in test group %d: fractional bytes not supported", group.OutputBits, group.ID)
+		}
+
+		if _, ok := k.hashAlgs[group.KTSConf.HashAlg]; !ok {
+			return nil, fmt.Errorf("test group %d specifies unsupported hash alg %q", group.ID, group.KTSConf.HashAlg)
+		}
+
+		var testResponses []ktsTestResponse
+		for _, test := range group.Tests {
+			test := test
+
+			var err error
+			switch group.Role {
+			case "initiator":
+				err = k.processInitiator(m, &testResponses, group.KTSConf.HashAlg, group.OutputBits, test)
+			case "responder":
+				err = k.processResponder(m, &testResponses, group.KTSConf.HashAlg, test)
+			default:
+				err = fmt.Errorf("unknown role %q", group.Role)
+			}
+
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		m.Barrier(func() {
+			response.Tests = testResponses
+			ret = append(ret, response)
+		})
+	}
+
+	if err := m.Flush(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+func (k *kts) processInitiator(m Transactable, responses *[]ktsTestResponse, hashAlg string, outputBits uint64, test ktsTest) error {
+	outputBytes := uint32le(uint32(outputBits / 8))
+
+	nBytes, err := hex.DecodeString(test.ServerN)
+	if err != nil {
+		return fmt.Errorf("invalid ServerN: %v", err)
+	}
+	eBytes, err := hex.DecodeString(test.ServerE)
+	if err != nil {
+		return fmt.Errorf("invalid SeverE: %v", err)
+	}
+
+	cmd := fmt.Sprintf("KTS-IFC/%s/initiator", hashAlg)
+	args := [][]byte{outputBytes, nBytes, eBytes}
+
+	m.TransactAsync(cmd, 2, args, func(result [][]byte) error {
+		*responses = append(*responses,
+			ktsTestResponse{
+				ID:   test.ID,
+				IutC: hex.EncodeToString(result[0]),
+				Dkm:  hex.EncodeToString(result[1]),
+			})
+		return nil
+	})
+
+	return nil
+}
+
+func (k *kts) processResponder(m Transactable, responses *[]ktsTestResponse, hashAlg string, test ktsTest) error {
+	nBytes, err := hex.DecodeString(test.IutN)
+	if err != nil {
+		return fmt.Errorf("invalid IutN: %v", err)
+	}
+
+	eBytes, err := hex.DecodeString(test.IutE)
+	if err != nil {
+		return fmt.Errorf("invalid IutE: %v", err)
+	}
+
+	pBytes, err := hex.DecodeString(test.IutP)
+	if err != nil {
+		return fmt.Errorf("invalid IutP: %v", err)
+	}
+
+	qBytes, err := hex.DecodeString(test.IutQ)
+	if err != nil {
+		return fmt.Errorf("invalid IutQ: %v", err)
+	}
+
+	dBytes, err := hex.DecodeString(test.IutD)
+	if err != nil {
+		return fmt.Errorf("invalid IutD: %v", err)
+	}
+
+	cBytes, err := hex.DecodeString(test.ServerC)
+	if err != nil {
+		return fmt.Errorf("invalid ServerC: %v", err)
+	}
+
+	cmd := fmt.Sprintf("KTS-IFC/%s/responder", hashAlg)
+	args := [][]byte{nBytes, eBytes, pBytes, qBytes, dBytes, cBytes}
+
+	m.TransactAsync(cmd, 1, args, func(result [][]byte) error {
+		*responses = append(*responses,
+			ktsTestResponse{
+				ID:  test.ID,
+				Dkm: hex.EncodeToString(result[0]),
+			})
+		return nil
+	})
+
+	return nil
+}

--- a/subprocess/subprocess.go
+++ b/subprocess/subprocess.go
@@ -146,6 +146,7 @@ func NewWithIO(cmd *exec.Cmd, in io.WriteCloser, out io.ReadCloser) *Subprocess 
 		"PBKDF":             &pbkdf{},
 		"ML-KEM":            &mlkem{},
 		"kdf-components":    &ssh{},
+		"KTS-IFC":           &kts{map[string]bool{"SHA-1": true, "SHA2-224": true, "SHA2-256": true, "SHA2-384": true, "SHA2-512": true, "SHA2-512/224": true, "SHA2-512/256": true, "SHA3-224": true, "SHA3-256": true, "SHA3-384": true, "SHA3-512": true}},
 	}
 	m.primitives["ECDSA"] = &ecdsa{"ECDSA", map[string]bool{"P-224": true, "P-256": true, "P-384": true, "P-521": true}, m.primitives}
 	m.primitives["DetECDSA"] = &ecdsa{"DetECDSA", map[string]bool{"P-224": true, "P-256": true, "P-384": true, "P-521": true}, m.primitives}


### PR DESCRIPTION
Based on the NIST ACVP specification:

  https://pages.nist.gov/ACVP/draft-hammett-acvp-kas-ifc.html

Some notable limitations:

* Only the KTS-OAEP-basic scheme is supported.
* Only the rsakpg1-basic keygen mode is supported.
* Only the AFT test type is supported (no partialVal function support).