### PR TITLE
acvp: use showExpected and dump provided/expected on fail

### DIFF
--- a/acvp/acvp.go
+++ b/acvp/acvp.go
@@ -660,3 +660,16 @@ type SessionResults struct {
 		Status string `json:"status"`
 	} `json:"results"`
 }
+
+type ValidationResults struct {
+	Retry       uint64 `json:"retry,omitempty"`
+	ID          uint64 `json:"vsId"`
+	Disposition string `json:"disposition"`
+	Tests       []struct {
+		ID       uint64         `json:"tcId"`
+		Result   string         `json:"result"`
+		Reason   string         `json:"reason"`
+		Expected map[string]any `json:"expected,omitempty"`
+		Provided map[string]any `json:"provided,omitempty"`
+	} `json:"tests"`
+}


### PR DESCRIPTION
When a submitted result set fails it's nice to be able to see specifically which test cases failed (e.g. AFT? MCT? both?) as well as what the server expected compared to what was provided.

See section 12 of the ACVP spec for more information:
  https://pages.nist.gov/ACVP/draft-fussell-acvp-spec.html#section-12.17.4